### PR TITLE
API 공통 응답 포맷 생성 및 전역적 에러 처리

### DIFF
--- a/src/main/java/com/goorm/sslim/controller/TestController.java
+++ b/src/main/java/com/goorm/sslim/controller/TestController.java
@@ -15,10 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/test")
 public class TestController {
 
-    @GetMapping("/excute")
+    @GetMapping("/execute")
     public ApiResponse<Void> test(@RequestParam String error) {
         if(error.equals("yes")) {
-            System.out.println("------------------------------");
             throw new TestException(ErrorCode._BAD_REQUEST);
         }
 

--- a/src/main/java/com/goorm/sslim/controller/TestController.java
+++ b/src/main/java/com/goorm/sslim/controller/TestController.java
@@ -1,0 +1,27 @@
+package com.goorm.sslim.controller;
+
+import com.goorm.sslim.global.code.ErrorCode;
+import com.goorm.sslim.global.code.ResponseCode;
+import com.goorm.sslim.global.exception.TestException;
+import com.goorm.sslim.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/test")
+public class TestController {
+
+    @GetMapping("/excute")
+    public ApiResponse<Void> test(@RequestParam String error) {
+        if(error.equals("yes")) {
+            System.out.println("------------------------------");
+            throw new TestException(ErrorCode._BAD_REQUEST);
+        }
+
+        return ApiResponse.onSuccess(ResponseCode.OK, null);
+    }
+}

--- a/src/main/java/com/goorm/sslim/entity/BaseEntity.java
+++ b/src/main/java/com/goorm/sslim/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.goorm.sslim.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+}

--- a/src/main/java/com/goorm/sslim/global/code/ErrorCode.java
+++ b/src/main/java/com/goorm/sslim/global/code/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.goorm.sslim.global.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    //Common
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON_400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON_401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "권한이 없습니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_404", "대상을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/goorm/sslim/global/code/ResponseCode.java
+++ b/src/main/java/com/goorm/sslim/global/code/ResponseCode.java
@@ -1,0 +1,17 @@
+package com.goorm.sslim.global.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseCode {
+
+    //Common
+    OK(HttpStatus.OK, "COMMON_200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/goorm/sslim/global/exception/GeneralException.java
+++ b/src/main/java/com/goorm/sslim/global/exception/GeneralException.java
@@ -1,0 +1,15 @@
+package com.goorm.sslim.global.exception;
+
+import com.goorm.sslim.global.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public GeneralException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/goorm/sslim/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goorm/sslim/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package com.goorm.sslim.global.exception;
+
+import com.goorm.sslim.global.code.ErrorCode;
+import com.goorm.sslim.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // 직접 정의한 비즈니스 로직 상의 예외를 처리
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Object>> handleGeneralException(GeneralException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Object> response = ApiResponse.onFailure(errorCode);
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    // @Valid나 @Validation에서 유효성 검증 실패했을 때
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        ErrorCode errorCode = ErrorCode._BAD_REQUEST;
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return new ResponseEntity<>(
+                ApiResponse.onFailure(errorCode, message, null),
+                errorCode.getHttpStatus()
+        );
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(
+            TypeMismatchException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        ErrorCode errorCode = ErrorCode._BAD_REQUEST;
+        String message = String.format("'%s' 파라미터의 타입이 잘못되었습니다. 필요한 타입: '%s'",
+                e.getPropertyName(),
+                e.getRequiredType().getSimpleName());
+
+        return new ResponseEntity<>(
+                ApiResponse.onFailure(errorCode, message, null),
+                errorCode.getHttpStatus()
+        );
+    }
+
+    // 지정되지 않은 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleAllExceptions(Exception e) {
+        e.printStackTrace();
+        ErrorCode errorCode = ErrorCode._INTERNAL_SERVER_ERROR;
+        return new ResponseEntity<>(
+                ApiResponse.onFailure(errorCode),
+                errorCode.getHttpStatus()
+        );
+    }
+}
+

--- a/src/main/java/com/goorm/sslim/global/exception/TestException.java
+++ b/src/main/java/com/goorm/sslim/global/exception/TestException.java
@@ -1,0 +1,10 @@
+package com.goorm.sslim.global.exception;
+
+import com.goorm.sslim.global.code.ErrorCode;
+
+public class TestException extends GeneralException{
+
+    public TestException(ErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/goorm/sslim/global/response/ApiResponse.java
+++ b/src/main/java/com/goorm/sslim/global/response/ApiResponse.java
@@ -2,6 +2,7 @@ package com.goorm.sslim.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.goorm.sslim.global.code.ErrorCode;
 import com.goorm.sslim.global.code.ResponseCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/goorm/sslim/global/response/ApiResponse.java
+++ b/src/main/java/com/goorm/sslim/global/response/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.goorm.sslim.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.goorm.sslim.global.code.ErrorCode;
 import com.goorm.sslim.global.code.ResponseCode;
@@ -12,7 +13,8 @@ import lombok.Getter;
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
 public class ApiResponse<T> {
 
-    private final boolean isSuccess;
+    @JsonProperty("isSuccess")
+    private final boolean success;
     private final String code;
     private final String message;
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/goorm/sslim/global/response/ApiResponse.java
+++ b/src/main/java/com/goorm/sslim/global/response/ApiResponse.java
@@ -1,0 +1,56 @@
+package com.goorm.sslim.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.goorm.sslim.global.code.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T result;
+
+    public static <T> ApiResponse<T> onSuccess(ResponseCode code, T result) {
+        return new ApiResponse<>(
+                true,
+                code.getCode(),
+                code.getMessage(),
+                result
+        );
+    }
+
+    public static <T> ApiResponse<T> onFailure(ErrorCode code, T result) {
+        return new ApiResponse<>(
+                false,
+                code.getCode(),
+                code.getMessage(),
+                result
+        );
+    }
+
+    public static <T> ApiResponse<T> onFailure(ErrorCode code) {
+        return new ApiResponse<>(
+                false,
+                code.getCode(),
+                code.getMessage(),
+                null
+        );
+    }
+
+    // 동적으로 생성한 상세 메시지 사용
+    public static <T> ApiResponse<T> onFailure(ErrorCode code, String message, T result) {
+        return new ApiResponse<>(
+                false,
+                code.getCode(),
+                message,
+                result
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
     port: 8080
 
   datasource:
-    url: ${DB_URL:jdbc:mysql://localhost:3306/seasonthon_db}
-    username: ${DB_USER:root}
-    password: ${DB_PASSWORD:dbpw}
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
1. API 공통 응답 포맷 생성
```
{
  "isSuccess": true,
  "code": "COMMON_200",
  "message": "성공입니다."
}
```

3. 전역적 에러 처리 추가
```
{
  "isSuccess": false,
  "code": "COMMON_400",
  "message": "잘못된 요청입니다."
}
```