### PR TITLE
feat: 오피스텔 전월세 API 연동 및 데이터 처리 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
-    
+     
     // Spring WebFlux (WebClient 사용)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     

--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,21 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    
+    // Spring WebFlux (WebClient 사용)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    
+	// JAXB API
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api'
+    
+    // JAXB 구현체
+    implementation 'org.glassfish.jaxb:jaxb-runtime'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
-
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/goorm/sslim/config/WebClientConfig.java
+++ b/src/main/java/com/goorm/sslim/config/WebClientConfig.java
@@ -1,0 +1,19 @@
+package com.goorm.sslim.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+	private static final String OFFICETEL_API_URL = "http://apis.data.go.kr/1613000/RTMSDataSvcOffiRent";
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+            .baseUrl(OFFICETEL_API_URL)
+            .build();
+    }
+	
+}

--- a/src/main/java/com/goorm/sslim/housingCost/controller/HousingCostController.java
+++ b/src/main/java/com/goorm/sslim/housingCost/controller/HousingCostController.java
@@ -1,0 +1,5 @@
+package com.goorm.sslim.housingCost.controller;
+
+public class HousingCostController {
+
+}

--- a/src/main/java/com/goorm/sslim/housingCost/dto/HousingCostDto.java
+++ b/src/main/java/com/goorm/sslim/housingCost/dto/HousingCostDto.java
@@ -1,0 +1,34 @@
+package com.goorm.sslim.housingCost.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HousingCostDto {
+
+	private Long housingCostId;
+	
+	private Long regionId;
+	
+	private String housingType; 	// 주거형태 (예: "Officetel", "Apartment")
+	
+    private double exclusiveArea; 	// 전용면적 (excluUseAr)
+    
+    private double deposit; 		// 보증금 (deposit)
+    
+    private double monthlyRent; 	// 월세 (monthlyRent)
+    
+    private String sggNm; 			// 시군구 (sggNm)
+    
+    private String umdNm;			// 법정동 (umdNm)
+    
+    private int dealYear;			// 계약년도 (dealYear)
+    
+    private int dealMonth;			// 계약월 (dealMonth)
+	
+}

--- a/src/main/java/com/goorm/sslim/housingCost/dto/OfficetelRentDto.java
+++ b/src/main/java/com/goorm/sslim/housingCost/dto/OfficetelRentDto.java
@@ -1,0 +1,45 @@
+package com.goorm.sslim.housingCost.dto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import lombok.Data;
+
+@Data
+@XmlAccessorType(XmlAccessType.FIELD)
+public class OfficetelRentDto {
+
+	@XmlElement(name = "buildYear")
+    private String buildYear; // 건축년도
+    
+    @XmlElement(name = "dealDay")
+    private String dealDay; // 계약일
+    
+    @XmlElement(name = "dealMonth")
+    private String dealMonth; // 계약월
+    
+    @XmlElement(name = "dealYear")
+    private String dealYear; // 계약년도
+    
+    @XmlElement(name = "deposit")
+    private String deposit; // 보증금액 (만원)
+    
+    @XmlElement(name = "excluUseAr")
+    private double excluUseAr; // 전용면적
+    
+    @XmlElement(name = "monthlyRent")
+    private String monthlyRent; // 월세금액 (만원)
+    
+    @XmlElement(name = "offiNm")
+    private String offiNm; // 단지명
+    
+    @XmlElement(name = "sggCd")
+    private String sggCd; // 지역코드
+    
+    @XmlElement(name = "sggNm")
+    private String sggNm; // 시군구
+    
+    @XmlElement(name = "umdNm")
+    private String umdNm; // 법정동
+	
+}

--- a/src/main/java/com/goorm/sslim/housingCost/entity/HousingCost.java
+++ b/src/main/java/com/goorm/sslim/housingCost/entity/HousingCost.java
@@ -1,0 +1,41 @@
+package com.goorm.sslim.housingCost.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "HOUSING_COST")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HousingCost {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long housingCostId;
+	
+	private Long regionId;
+    
+    private String housingType;
+    
+    private double exclusiveArea;
+    
+    private double deposit;
+    
+    private double monthlyRent;
+    
+    private String sggNm;
+    
+    private String umdNm;
+    
+    private int dealYear;
+    
+    private int dealMonth;
+	
+    
+    
+}

--- a/src/main/java/com/goorm/sslim/housingCost/repository/HousingCostRepository.java
+++ b/src/main/java/com/goorm/sslim/housingCost/repository/HousingCostRepository.java
@@ -1,9 +1,11 @@
 package com.goorm.sslim.housingCost.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.goorm.sslim.housingCost.entity.HousingCost;
 
+@Repository
 public interface HousingCostRepository extends JpaRepository<HousingCost, Long> {
 
 }

--- a/src/main/java/com/goorm/sslim/housingCost/repository/HousingCostRepository.java
+++ b/src/main/java/com/goorm/sslim/housingCost/repository/HousingCostRepository.java
@@ -1,0 +1,9 @@
+package com.goorm.sslim.housingCost.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goorm.sslim.housingCost.entity.HousingCost;
+
+public interface HousingCostRepository extends JpaRepository<HousingCost, Long> {
+
+}

--- a/src/main/java/com/goorm/sslim/housingCost/service/HousingCostService.java
+++ b/src/main/java/com/goorm/sslim/housingCost/service/HousingCostService.java
@@ -6,12 +6,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.goorm.sslim.housingCost.dto.HousingCostDto;
 import com.goorm.sslim.housingCost.dto.OfficetelRentDto;
+import com.goorm.sslim.housingCost.entity.HousingCost;
+import com.goorm.sslim.housingCost.repository.HousingCostRepository;
 import com.goorm.sslim.housingCost.xml.Body;
 import com.goorm.sslim.housingCost.xml.Items;
 import com.goorm.sslim.housingCost.xml.Response;
@@ -24,25 +27,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class HousingCostService {
 	
-    private final WebClient webClient;
-    private static final String API_URL = "http://apis.data.go.kr/1613000/RTMSDataSvcOffiRent";
+	private final WebClient webClient;
+	private final HousingCostRepository housingCostRepository;
     
-    // API 키 추후 환경변수로 변환
-    private final String officetelKey = "2d4ea1d47d8bb9f264dac2c60c50527ce80b29540db5eaaa1e026f22f629e9de";
+    @Value("${custom.api.officetel-key}")
+    private String officetelKey;
+    
+    private static final String API_PATH = "/getRTMSDataSvcOffiRent?&LAWD_CD={lawdCd}&DEAL_YMD={dealYmd}&serviceKey={serviceKey}";
 
     public List<HousingCostDto> getOfficetelRentData(String lawdCd, String dealYmd) {
-    	
-        String uri = "/getRTMSDataSvcOffiRent?serviceKey={serviceKey}&LAWD_CD={lawdCd}&DEAL_YMD={dealYmd}";
-        
+
         try {
             String xmlResponse = webClient.get()
-                .uri(uri, officetelKey, lawdCd, dealYmd)
+                .uri(API_PATH, lawdCd, dealYmd, officetelKey)
                 .accept(MediaType.APPLICATION_XML)
                 .retrieve()
                 .bodyToMono(String.class)
                 .block();
 
-            // API 응답이 에러 메시지인 경우를 먼저 체크합니다.
             if (xmlResponse.contains("<OpenAPI_ServiceResponse>")) {
                 System.err.println("API 호출 실패: 유효하지 않은 API 키, IP 주소 불일치 또는 잘못된 요청입니다.");
                 System.err.println("--- API 서버 응답 ---\n" + xmlResponse);
@@ -59,7 +61,7 @@ public class HousingCostService {
                 .orElse(Collections.emptyList());
 
             return officetelData.stream()
-                .filter(item -> item.getExcluUseAr() <= 40.0)	// 전용면적 40㎡ 이하 필터링
+                .filter(item -> item.getExcluUseAr() <= 40.0)
                 .map(item -> HousingCostDto.builder()
                         .housingType("Officetel")
                         .exclusiveArea(item.getExcluUseAr())
@@ -76,21 +78,35 @@ public class HousingCostService {
             System.err.println("오피스텔 API 호출 중 오류 발생: " + e.getMessage());
             return Collections.emptyList();
         }
-        
     }
     
-//    public void fetchAndSaveOfficetelData(String lawdCd, String dealYmd) {
-//    	
-//        // 1. 오피스텔 API 호출 및 데이터 파싱
-//        List<HousingCostDto> officetelDataList = getOfficetelRentData(lawdCd, dealYmd);
-//
-//        // 2. 파싱된 데이터를 DB에 저장
-//        if (!officetelDataList.isEmpty()) {
-//            System.out.println("성공적으로 파싱된 오피스텔 데이터: " + officetelDataList.size() + "건");
-//        } else {
-//            System.out.println("API 호출 결과 데이터가 없거나 파싱에 실패했습니다.");
-//        }
-//        
-//    }
+    public void fetchAndSaveOfficetelData(String lawdCd, String dealYmd) {
+    	
+	    List<HousingCostDto> officetelDataList = getOfficetelRentData(lawdCd, dealYmd);
+	
+	    if (!officetelDataList.isEmpty()) {
+	        List<HousingCost> housingCosts = officetelDataList.stream()
+	                .map(dto -> {
+	                    HousingCost entity = new HousingCost();
+	                    entity.setHousingType(dto.getHousingType());
+	                    entity.setExclusiveArea(dto.getExclusiveArea());
+	                    entity.setDeposit(dto.getDeposit());
+	                    entity.setMonthlyRent(dto.getMonthlyRent());
+	                    entity.setSggNm(dto.getSggNm());
+	                    entity.setUmdNm(dto.getUmdNm());
+	                    entity.setDealYear(dto.getDealYear());
+	                    entity.setDealMonth(dto.getDealMonth());
+	                    return entity;
+	                })
+	                .collect(Collectors.toList());
+	
+	        housingCostRepository.saveAll(housingCosts);
+	        System.out.println("성공적으로 " + housingCosts.size() + "건의 오피스텔 데이터가 저장되었습니다.");
+	        
+	    } else {
+	        System.out.println("저장할 데이터가 없습니다.");
+	    }
+    
+    }
     
 }

--- a/src/main/java/com/goorm/sslim/housingCost/service/HousingCostService.java
+++ b/src/main/java/com/goorm/sslim/housingCost/service/HousingCostService.java
@@ -1,0 +1,96 @@
+package com.goorm.sslim.housingCost.service;
+
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.goorm.sslim.housingCost.dto.HousingCostDto;
+import com.goorm.sslim.housingCost.dto.OfficetelRentDto;
+import com.goorm.sslim.housingCost.xml.Body;
+import com.goorm.sslim.housingCost.xml.Items;
+import com.goorm.sslim.housingCost.xml.Response;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HousingCostService {
+	
+    private final WebClient webClient;
+    private static final String API_URL = "http://apis.data.go.kr/1613000/RTMSDataSvcOffiRent";
+    
+    // API 키 추후 환경변수로 변환
+    private final String officetelKey = "2d4ea1d47d8bb9f264dac2c60c50527ce80b29540db5eaaa1e026f22f629e9de";
+
+    public List<HousingCostDto> getOfficetelRentData(String lawdCd, String dealYmd) {
+    	
+        String uri = "/getRTMSDataSvcOffiRent?serviceKey={serviceKey}&LAWD_CD={lawdCd}&DEAL_YMD={dealYmd}";
+        
+        try {
+            String xmlResponse = webClient.get()
+                .uri(uri, officetelKey, lawdCd, dealYmd)
+                .accept(MediaType.APPLICATION_XML)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+            // API 응답이 에러 메시지인 경우를 먼저 체크합니다.
+            if (xmlResponse.contains("<OpenAPI_ServiceResponse>")) {
+                System.err.println("API 호출 실패: 유효하지 않은 API 키, IP 주소 불일치 또는 잘못된 요청입니다.");
+                System.err.println("--- API 서버 응답 ---\n" + xmlResponse);
+                return Collections.emptyList();
+            }
+
+            JAXBContext jaxbContext = JAXBContext.newInstance(Response.class);
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            Response response = (Response) unmarshaller.unmarshal(new StringReader(xmlResponse));
+
+            List<OfficetelRentDto> officetelData = Optional.ofNullable(response.getBody())
+                .map(Body::getItems)
+                .map(Items::getItem)
+                .orElse(Collections.emptyList());
+
+            return officetelData.stream()
+                .filter(item -> item.getExcluUseAr() <= 40.0)	// 전용면적 40㎡ 이하 필터링
+                .map(item -> HousingCostDto.builder()
+                        .housingType("Officetel")
+                        .exclusiveArea(item.getExcluUseAr())
+                        .deposit(Double.parseDouble(item.getDeposit().replace(",", "")))
+                        .monthlyRent(Double.parseDouble(item.getMonthlyRent().replace(",", "")))
+                        .sggNm(item.getSggNm())
+                        .umdNm(item.getUmdNm())
+                        .dealYear(Integer.parseInt(item.getDealYear()))
+                        .dealMonth(Integer.parseInt(item.getDealMonth()))
+                        .build())
+                .collect(Collectors.toList());
+            
+        } catch (Exception e) {
+            System.err.println("오피스텔 API 호출 중 오류 발생: " + e.getMessage());
+            return Collections.emptyList();
+        }
+        
+    }
+    
+//    public void fetchAndSaveOfficetelData(String lawdCd, String dealYmd) {
+//    	
+//        // 1. 오피스텔 API 호출 및 데이터 파싱
+//        List<HousingCostDto> officetelDataList = getOfficetelRentData(lawdCd, dealYmd);
+//
+//        // 2. 파싱된 데이터를 DB에 저장
+//        if (!officetelDataList.isEmpty()) {
+//            System.out.println("성공적으로 파싱된 오피스텔 데이터: " + officetelDataList.size() + "건");
+//        } else {
+//            System.out.println("API 호출 결과 데이터가 없거나 파싱에 실패했습니다.");
+//        }
+//        
+//    }
+    
+}

--- a/src/main/java/com/goorm/sslim/housingCost/xml/Body.java
+++ b/src/main/java/com/goorm/sslim/housingCost/xml/Body.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class Body {
 	
 	@XmlElement(name = "items")
-    private Items items;
+    private Items items; 
     private int numOfRows;
     private int pageNo;
     private int totalCount;

--- a/src/main/java/com/goorm/sslim/housingCost/xml/Body.java
+++ b/src/main/java/com/goorm/sslim/housingCost/xml/Body.java
@@ -1,0 +1,20 @@
+package com.goorm.sslim.housingCost.xml;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Body {
+	
+	@XmlElement(name = "items")
+    private Items items;
+    private int numOfRows;
+    private int pageNo;
+    private int totalCount;
+    
+}

--- a/src/main/java/com/goorm/sslim/housingCost/xml/Items.java
+++ b/src/main/java/com/goorm/sslim/housingCost/xml/Items.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Items {
 	
-    @XmlElement(name = "item")
+    @XmlElement(name = "item") 
     private List<OfficetelRentDto> item;
     
 }

--- a/src/main/java/com/goorm/sslim/housingCost/xml/Items.java
+++ b/src/main/java/com/goorm/sslim/housingCost/xml/Items.java
@@ -1,0 +1,21 @@
+package com.goorm.sslim.housingCost.xml;
+
+import java.util.List;
+
+import com.goorm.sslim.housingCost.dto.OfficetelRentDto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Items {
+	
+    @XmlElement(name = "item")
+    private List<OfficetelRentDto> item;
+    
+}

--- a/src/main/java/com/goorm/sslim/housingCost/xml/Response.java
+++ b/src/main/java/com/goorm/sslim/housingCost/xml/Response.java
@@ -1,0 +1,19 @@
+package com.goorm.sslim.housingCost.xml;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@XmlRootElement(name = "response")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Response {
+	
+	@XmlElement(name = "body")
+    private Body body;
+	
+}

--- a/src/main/java/com/goorm/sslim/housingCost/xml/Response.java
+++ b/src/main/java/com/goorm/sslim/housingCost/xml/Response.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Response {
 	
-	@XmlElement(name = "body")
+	@XmlElement(name = "body") 
     private Body body;
 	
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,7 @@ spring:
 #    init:
 #      mode: always
 #      data-locations: classpath:data.sql # 앱 실행 시, 초기 삽입 데이터
+
+custom:
+  api:
+    officetel-key: "2d4ea1d47d8bb9f264dac2c60c50527ce80b29540db5eaaa1e026f22f629e9de"


### PR DESCRIPTION
작업 내용
- 국토교통부 오피스텔 전월세 API를 연동하여 데이터를 받아오고, DTO로 변환하는 기본 기능을 구현했습니다.
- WebClientConfig를 도입하여 API 기본 URL을 관리하도록 코드를 정리했습니다.
- HousingCostService에서 API 호출 및 XML 데이터 파싱 로직을 완성했습니다.

다음 단계 (TODO)
- Region 연동: 현재는 lawdCd(지역 코드)를 수동으로 입력해야 합니다. Region 엔티티와 연결하여 지역명을 기반으로 lawdCd를 자동으로 가져오는 로직이 필요합니다.
- DB 저장 로직: API를 통해 가져온 데이터를 HousingCost 엔티티로 변환하여 DB에 저장하는 로직을 구제적으로 추가해야 합니다.
