### PR TITLE
feat: 지역 엔티티 스키마 및 관련 DTO/Repository 구현

### DIFF
--- a/src/main/java/com/goorm/sslim/region/dto/RegionDto.java
+++ b/src/main/java/com/goorm/sslim/region/dto/RegionDto.java
@@ -1,0 +1,28 @@
+package com.goorm.sslim.region.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RegionDto {
+
+	private Long regionId; 			// 지역 PK (기본 키)
+	
+    private String regionSiName; 	// 시/도명
+    
+    private String regionSggName; 	// 시군구명
+    
+    private String regionSggCode; 	// 시군구 코드
+    
+    private String lawdCd; 			// 국토교통부 API 코드
+    
+    private String regionKcaCode; 	// 한국소비자원 API 코드
+    
+    private String regionStcisCode; // 교통카드 API 코드
+	
+}

--- a/src/main/java/com/goorm/sslim/region/entity/Region.java
+++ b/src/main/java/com/goorm/sslim/region/entity/Region.java
@@ -1,0 +1,31 @@
+package com.goorm.sslim.region.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Entity
+@Data
+@Table(name = "REGION")
+public class Region {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long regionId; // 지역 PK (기본 키)
+
+    private String regionSiName; // 시/도명 (예: "서울특별시")
+
+    private String regionSggName; // 시군구명 (예: "종로구")
+
+    private String regionSggCode; // 시군구 코드 (행정동 코드와 동일 운용 가능)
+
+    private String lawdCd; // 국토교통부 전월세 실거래 API 코드 (LAWD_CD)
+
+    private String regionKcaCode; // 한국소비자원 참가격 지역코드
+
+    private String regionStcisCode; // 교통카드(STCIS) 지역코드
+	
+}

--- a/src/main/java/com/goorm/sslim/region/repository/RegionRepository.java
+++ b/src/main/java/com/goorm/sslim/region/repository/RegionRepository.java
@@ -1,0 +1,9 @@
+package com.goorm.sslim.region.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goorm.sslim.region.entity.Region;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+
+}


### PR DESCRIPTION
작업 내용
- 다양한 공공 API (국토교통부, 한국소비자원, 교통카드 등)에서 사용할 지역 정보 통합 관리를 위한 Region 엔티티를 설계했습니다.
- Region 엔티티의 필드에 맞춰 RegionDto를 정의했습니다.
- Region 엔티티와 연동하는 RegionRepository를 구현했습니다.

다음 단계 (TODO)
- 데이터 초기 적재: 공공데이터 포털에서 지역 코드 데이터를 다운로드받아 초기 데이터를 DB에 저장하는 스크립트 또는 배치 기능을 구현해야 합니다.
- HousingCostService 연동: HousingCostService에서 API 호출 시 수동으로 입력하던 lawdCd를 RegionRepository를 통해 동적으로 가져오도록 수정해야 합니다.