### PR TITLE
feat: 오피스텔 및 아파트 API 연동 및 DB 저장 테스트 완료

### DIFF
--- a/src/main/java/com/goorm/sslim/housingCost/dto/HousingCostDto.java
+++ b/src/main/java/com/goorm/sslim/housingCost/dto/HousingCostDto.java
@@ -26,6 +26,9 @@ public class HousingCostDto {
 
     @XmlElement(name = "sggNm")
     private String sggNm;
+    
+    @XmlElement(name = "sggCd")
+    private String sggCd;
 
     @XmlElement(name = "umdNm")
     private String umdNm;

--- a/src/main/java/com/goorm/sslim/housingCost/entity/HousingCost.java
+++ b/src/main/java/com/goorm/sslim/housingCost/entity/HousingCost.java
@@ -37,8 +37,11 @@ public class HousingCost {
     @Column(name = "MONTHLY_RENT", nullable = false)
     private double monthlyRent;
 
-    @Column(name = "SGG_NM", nullable = false)
+    @Column(name = "SGG_NM", nullable = true)
     private String sggNm;
+
+    @Column(name = "SGG_CD", nullable = true)
+    private String sggCd;
 
     @Column(name = "UMD_NM", nullable = false)
     private String umdNm;

--- a/src/main/java/com/goorm/sslim/housingCost/service/HousingCostService.java
+++ b/src/main/java/com/goorm/sslim/housingCost/service/HousingCostService.java
@@ -105,8 +105,16 @@ public class HousingCostService {
         List<HousingCostDto> dtoList = response.getBody().getItems().getItem();
 
         List<HousingCost> entities = dtoList.stream()
+        		// 1. 전용면적 40㎡ 이하만
+                .filter(dto -> dto.getExclusiveArea() <= 40.0)
+                
+                // 2. 보증금/월세가 동시에 0인 경우 제외
+                .filter(dto -> !(dto.getDeposit() == 0.0 && dto.getMonthlyRent() == 0.0))
+                
+                // 3. 매핑
                 .map(dto -> HousingCost.builder()
                         .sggNm(dto.getSggNm())
+                        .sggCd(dto.getSggCd())
                         .umdNm(dto.getUmdNm())
                         .deposit(dto.getDeposit())
                         .monthlyRent(dto.getMonthlyRent())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,11 +4,10 @@ spring:
 
   server:
     port: 8080
-
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://localhost:3306/SSLIM?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -29,6 +28,6 @@ spring:
 #      mode: always
 #      data-locations: classpath:data.sql # 앱 실행 시, 초기 삽입 데이터
 
-custom:
-  api:
-    officetel-key: "2d4ea1d47d8bb9f264dac2c60c50527ce80b29540db5eaaa1e026f22f629e9de"
+apis:
+  rtms:
+    service-key: "2d4ea1d47d8bb9f264dac2c60c50527ce80b29540db5eaaa1e026f22f629e9de"

--- a/src/test/java/com/goorm/sslim/housing/HousingCostApiTest.java
+++ b/src/test/java/com/goorm/sslim/housing/HousingCostApiTest.java
@@ -1,0 +1,112 @@
+package com.goorm.sslim.housing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.goorm.sslim.housingCost.entity.HousingCost;
+import com.goorm.sslim.housingCost.repository.HousingCostRepository;
+import com.goorm.sslim.housingCost.service.HousingCostService;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+public class HousingCostApiTest {
+
+	@Autowired
+    private HousingCostService housingCostService;
+
+    @Autowired
+    private HousingCostRepository housingCostRepository;
+
+    @Test
+    @DisplayName("오피스텔 API → 응답 파싱 → DB 저장까지 정상 동작 확인")
+    @Transactional // 테스트 끝나면 자동 롤백 (DB 깨끗하게 유지)
+    void fetchAndSave_officetel_success() {
+        // given
+        String lawdCd = "11110";  // 종로구
+        String dealYmd = "202407"; // 2024년 7월
+
+        long beforeCount = housingCostRepository.count();
+
+        // when
+        housingCostService.fetchAndSaveOfficetel(lawdCd, dealYmd);
+
+        // then
+        List<HousingCost> saved = housingCostRepository.findAll();
+        long afterCount = saved.size();
+
+        System.out.println("===== DB 저장 결과 =====");
+        System.out.println("저장 전 건수: " + beforeCount);
+        System.out.println("저장 후 건수: " + afterCount);
+        assertThat(afterCount).isGreaterThan(beforeCount);
+
+        // 샘플 5건 출력
+        System.out.println("===== 샘플 데이터 (상위 5건) =====");
+        for (int i = 0; i < Math.min(5, saved.size()); i++) {
+            HousingCost h = saved.get(i);
+            System.out.println("[" + (i + 1) + "]");
+            System.out.println("  시군구: " + h.getSggNm());
+            System.out.println("  법정동: " + h.getUmdNm());
+            System.out.println("  전용면적: " + h.getExclusiveArea());
+            System.out.println("  보증금: " + h.getDeposit());
+            System.out.println("  월세: " + h.getMonthlyRent());
+            System.out.println("  계약년도: " + h.getDealYear());
+            System.out.println("  계약월: " + h.getDealMonth());
+            System.out.println("  주거형태: " + h.getHousingType());
+        }
+
+        // 무결성 검증
+        assertThat(saved)
+                .allSatisfy(h -> {
+                    assertThat(h.getDealYear()).isNotZero();
+                    assertThat(h.getDealMonth()).isNotZero();
+                    assertThat(h.getSggNm()).isNotBlank();
+                    assertThat(h.getUmdNm()).isNotBlank();
+                    assertThat(h.getHousingType().name()).isEqualTo("OFFICETEL");
+                });
+    }
+    
+    @Test
+    @DisplayName("아파트 API → 응답 파싱 → DB 저장까지 정상 동작 확인")
+    @Transactional // 테스트 후 DB 롤백
+    void fetchAndSave_apartment_success() {
+        // given
+        String lawdCd = "11110";   // 종로구
+        String dealYmd = "202407"; // 2024년 7월 데이터
+
+        long before = housingCostRepository.count();
+
+        // when
+        housingCostService.fetchAndSaveApartment(lawdCd, dealYmd);
+
+        // then
+        long after = housingCostRepository.count();
+        System.out.println("저장 전: " + before + ", 저장 후: " + after);
+
+        List<HousingCost> saved = housingCostRepository.findAll();
+
+        // 샘플 출력
+        saved.stream().limit(5).forEach(h -> {
+            System.out.println("=== 아파트 데이터 ===");
+            System.out.println("시군구: " + h.getSggNm());
+            System.out.println("시군구 코드: " + h.getSggCd());
+            System.out.println("법정동: " + h.getUmdNm());
+            System.out.println("전용면적: " + h.getExclusiveArea());
+            System.out.println("보증금: " + h.getDeposit());
+            System.out.println("월세: " + h.getMonthlyRent());
+            System.out.println("계약년도: " + h.getDealYear());
+            System.out.println("계약월: " + h.getDealMonth());
+            System.out.println("주거형태: " + h.getHousingType());
+        });
+
+        // 간단 검증
+        assertThat(after).isGreaterThan(before);
+    }
+	
+}


### PR DESCRIPTION
### 변경 내용
- 국토부 오피스텔/아파트 전월세 실거래가 API 연동 로직 추가 및 DB 저장 테스트 완료
- HousingCost 엔티티 및 DTO 매핑 확장 (sggCd 필드 추가)
- 저장 전 데이터 필터링 로직 적용
  - 전용면적 40㎡ 이하 데이터만 저장
  - 보증금·월세가 모두 0인 데이터 제외

### TODO
- 현재는 오피스텔/아파트 API만 호출 및 저장 테스트 완료
- 동일한 방식으로 다른 API들도 검증 필요
  - 국토교통부 연립다세대 전월세 실거래가 자료
  - 국토교통부 단독다가구 전월세 실거래가 자료