### PR TITLE
refactor: WebClient 경로 분리 및 bean 이름 명시

### DIFF
--- a/src/main/java/com/goorm/sslim/config/WebClientConfig.java
+++ b/src/main/java/com/goorm/sslim/config/WebClientConfig.java
@@ -9,11 +9,19 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 	
-	@Bean
+	@Bean(name = "rtmsWebClient")
     public WebClient rtmsWebClient(WebClient.Builder builder) {
         return builder
-            .baseUrl("http://apis.data.go.kr/1613000") // 공통 루트
+            .baseUrl("http://apis.data.go.kr/1613000") // 국토부 실거래가 공통 루트
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML_VALUE)
+            .build();
+    }
+	
+	@Bean(name = "regionalCodeWebClient")
+    public WebClient regionalCodeWebClient(WebClient.Builder builder) {
+        return builder
+        	.baseUrl("https://apis.data.go.kr/1613000/RegionalCode") // 국토부 지역코드 루트
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
             .build();
     }
 	

--- a/src/main/java/com/goorm/sslim/housingCost/service/HousingCostService.java
+++ b/src/main/java/com/goorm/sslim/housingCost/service/HousingCostService.java
@@ -5,6 +5,7 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -19,17 +20,25 @@ import com.goorm.sslim.region.repository.RegionRepository;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.Unmarshaller;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class HousingCostService {
 	
-	private final WebClient webClient;
+	private final WebClient rtmsWebClient;
     private final HousingCostRepository housingCostRepository;
     private final RegionRepository regionRepository;
+    
+    public HousingCostService(
+            @Qualifier("rtmsWebClient") WebClient rtmsWebClient,
+            HousingCostRepository housingCostRepository,
+            RegionRepository regionRepository
+        ) {
+            this.rtmsWebClient = rtmsWebClient;
+            this.housingCostRepository = housingCostRepository;
+            this.regionRepository = regionRepository;
+    }
 
     @Value("${apis.rtms.service-key}")
     private String serviceKey;
@@ -201,7 +210,7 @@ public class HousingCostService {
     private String callRtmsApi(String path, String lawdCd, String dealYmd) {
     	
         try {
-            return webClient.get()
+            return rtmsWebClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path(path)
                             .queryParam("serviceKey", serviceKey)


### PR DESCRIPTION
## 개요
기존에 `HousingCostService` 내에서 직접 관리되던 WebClient 경로 설정을 별도의 `WebClientConfig` 클래스로 분리하고, Bean 이름을 명시하여 각 API별 WebClient를 명확히 구분할 수 있도록 리팩토링하였습니다.

## 주요 변경 사항
- **WebClientConfig**
  - API 경로별로 `@Bean` 등록
  - Base URL 및 공통 설정을 분리하여 재사용성 강화
- **HousingCostService**
  - 기존 하드코딩된 WebClient 호출을 의존성 주입(Bean 이름 기반)으로 변경
  - API 호출 시 명확한 WebClient 사용이 가능하도록 구조 개선
