### PR TITLE
test: 국토부 지역코드 및 주거비 API 연동 테스트 추가

### DIFF
--- a/src/test/java/com/goorm/sslim/housing/HousingCostApiTest.java
+++ b/src/test/java/com/goorm/sslim/housing/HousingCostApiTest.java
@@ -40,7 +40,9 @@ public class HousingCostApiTest {
     void setupRegion() {
         if (regionRepository.count() == 0) {
             Region r = new Region();
-            r.setLawdCd(TEST_LAWD_CD);
+            r.setLawdCd(TEST_LAWD_CD);   // 11110
+            r.setSiName("서울특별시");      // ✅ 필수값 채우기
+            r.setSggName("종로구");        // ✅ 필수값 채우기
             regionRepository.save(r);
         }
     }

--- a/src/test/java/com/goorm/sslim/region/RegionApiTest.java
+++ b/src/test/java/com/goorm/sslim/region/RegionApiTest.java
@@ -1,0 +1,80 @@
+package com.goorm.sslim.region;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+
+import com.goorm.sslim.region.entity.Region;
+import com.goorm.sslim.region.repository.RegionRepository;
+import com.goorm.sslim.region.service.RegionService;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+public class RegionApiTest {
+
+	@Autowired
+    private RegionService regionService;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @Autowired
+    private Environment env;
+	
+    /**
+     * 외부 API 키가 없거나 네트워크 환경이 아니면 테스트를 Skip
+     * - 실제 API 호출을 수행하는 통합 테스트이므로 방어적으로 처리
+     */
+    private void assumeServiceKeyPresent() {
+        String key = env.getProperty("apis.rtms.service-key");
+        assumeTrue(key != null && !key.isBlank(),
+                "apis.rtms.service-key 가 설정되지 않아 RTMS 통합 테스트를 건너뜁니다");
+    }
+    
+    @Test
+    @DisplayName("지역코드 API 호출 → 응답 파싱 → DB 저장")
+    void regionalCode_api_flow_success() {
+    	
+    	assumeServiceKeyPresent();
+
+        long before = regionRepository.count();
+
+        // 실제 서비스 호출
+        regionService.syncAllLawdCdNationwide();
+
+        long after = regionRepository.count();
+
+        // 저장 결과 검증
+        assertThat(after).isGreaterThan(before)
+            .withFailMessage("지역코드 API 호출 후 DB에 데이터가 저장되지 않았습니다.");
+
+        // 전체 건수와 일부 결과를 콘솔에 출력
+        System.out.println("===== REGION 저장 결과 =====");
+        System.out.println("Before count = " + before);
+        System.out.println("After count  = " + after);
+
+        // 저장된 엔트리 일부를 확인 (최대 5건)
+        List<Region> all = regionRepository.findAll();
+        all.stream().limit(5).forEach(r -> 
+            System.out.printf("lawdCd=%s, siName=%s, sggName=%s%n",
+                r.getLawdCd(), r.getSiName(), r.getSggName())
+        );
+        System.out.println("===========================");
+
+        // 첫 번째 엔트리 값 간단 검증
+        var first = all.get(0);
+        assertThat(first.getLawdCd()).hasSize(5);
+        assertThat(first.getSiName()).isNotBlank();
+        assertThat(first.getSggName()).isNotBlank();
+        
+    }
+    
+}


### PR DESCRIPTION
## 개요
국토부 지역코드 API와 주거비 API 연동 기능에 대한 기본 테스트 코드를 작성하여,  
호출 → 응답 파싱 → DB 저장 흐름이 정상적으로 동작하는지 검증했습니다.  
단, 현재 지역코드 API는 호출 한계치 초과로 인해 실제 동작 여부는 쿼터 복구 후 다시 확인이 필요합니다.

## 주요 변경 사항
- **HousingCostApiTest**
  - 아파트/오피스텔/단독다가구/연립다세대 API 호출 검증
  - API 응답을 DTO로 변환 후 Entity 저장까지 정상 동작하는지 확인
  - 데이터 부재 시, 테스트용 지역 코드(`11110`, 종로구) 기반으로 단순 검증 수행
- **RegionApiTest**
  - 지역코드 API 호출 및 응답 데이터 DTO/Entity 변환 검증
  - 현재는 API 호출 한계치 초과로 인해 재검증 필요